### PR TITLE
Fix bin tools output

### DIFF
--- a/bin/cleandeck-generate-app-key
+++ b/bin/cleandeck-generate-app-key
@@ -19,8 +19,8 @@ require_once __DIR__ . '/../Framework/Support/Utils/CDMessageFormatter.php';
 
 $cdmf = new CDMessageFormatter(
     'CleanDeck-Generate-App-Key',
-    'SUCCESS!' . PHP_EOL .
-    'A new "app_key" was generated in file .env.ini' . PHP_EOL .
+    'SUCCESS! ' .
+    'A new "app_key" was generated in file ".env.ini". ' .
     'Make sure "app_key" is used by all CleanDeck machines in the same stack.',
     'CleanDeck-Generate-App-Key Failed!'
 );

--- a/bin/cleandeck-unzip
+++ b/bin/cleandeck-unzip
@@ -51,7 +51,8 @@ if (!is_dir($destination_path)) {
 }
 
 $cdmf->content('Unzipping archive ' . $archive_path);
-$cdmf->content('Destination ' . $destination_path . PHP_EOL);
+$cdmf->content('Destination ' . $destination_path);
+$cdmf->nl();
 try {
     CleanDeckUnzip::run($archive_path, $destination_path);
 } catch (Exception $e) {
@@ -60,7 +61,8 @@ try {
     exit(1);
 }
 
-$cdmf->bold('Done!' . PHP_EOL);
+$cdmf->bold('Done!');
+$cdmf->nl();
 $cdmf->important('This utility extracts directory Application and file .env.ini only.');
 $cdmf->remark('Use OS tools such as *unzip* in order to extract the full contents of the archive. Make sure not to overwrite important content.');
 


### PR DESCRIPTION
Rectify common error with CDMessageFormatter: no new lines for content. Use function 'nl' for new lines.