### PR TITLE
Eliminate Nginx warning on duplicate file type text/html

### DIFF
--- a/deploy/settings/nginx/nginx-cleandeck-ssl-http2-new.conf
+++ b/deploy/settings/nginx/nginx-cleandeck-ssl-http2-new.conf
@@ -74,7 +74,7 @@ http {
 
         gzip                on;
         gzip_comp_level     3;
-        gzip_types          text/html text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg;
+        gzip_types          text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg;
 
         client_max_body_size 8m;
 

--- a/deploy/settings/nginx/nginx-cleandeck-ssl-http2-old.conf
+++ b/deploy/settings/nginx/nginx-cleandeck-ssl-http2-old.conf
@@ -72,7 +72,7 @@ http {
 
         gzip                on;
         gzip_comp_level     3;
-        gzip_types          text/html text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg
+        gzip_types          text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg
 
         client_max_body_size 8m;
 

--- a/deploy/settings/nginx/nginx-cleandeck.conf
+++ b/deploy/settings/nginx/nginx-cleandeck.conf
@@ -64,7 +64,7 @@ http {
 
         gzip                on;
         gzip_comp_level     3;
-        gzip_types          text/html text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg
+        gzip_types          text/plain text/xml text/css text/javascript application/javascript image/vnd.microsoft.icon image/png image/gif image/svg+xml image/jpeg
 
         client_max_body_size 8m;
 


### PR DESCRIPTION
Eliminated file type text/html from the list of files to be compressed by Nginx which compressed this type by default.