### PR TITLE
Remove keygen output when creating a new project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
             "Framework\\Support\\Scripts\\ComposerScripts::populateSslSettingsFiles",
             "Framework\\Support\\Scripts\\ComposerScripts::generateSslPassword",
             "Framework\\Support\\Utils\\OpenSSLUtils::generateSelfSignedCertificate",
-            "composer exec cleandeck-generate-app-key",
+            "Framework\\Support\\Scripts\\ComposerScripts::keygen",
             "Framework\\Support\\Scripts\\ComposerScripts::postCreateProjectText"
         ],
         "analyze": [


### PR DESCRIPTION
Keep only content directly related with create-project and hide all unnecessary output including keygen output